### PR TITLE
Move @types/ip to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   "dependencies": {
     "@oclif/command": "^1.5.18",
     "@oclif/config": "^1.13.2",
-    "@types/ip": "^1.1.0",
     "aws-sdk": "^2.499.0",
     "chalk": "^2.4.2",
     "cli-ux": "^5.3.1",
@@ -29,6 +28,7 @@
     "@types/chai": "^4.1.7",
     "@types/chalk": "^2.2.0",
     "@types/inquirer": "0.0.43",
+    "@types/ip": "^1.1.0",
     "@types/js-yaml": "^3.12.1",
     "@types/mocha": "^5.2.7",
     "@types/node": "^10.14.13",


### PR DESCRIPTION
Seems it was late when I added the `ip` dependency because I also added `@types/ip` instead of moving it to dev dependencies. Anyhow this PR is doing exactly that.