### PR TITLE
Change runType to buildOrigin as seems to be a better fit

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -3,7 +3,7 @@ import {cli} from 'cli-ux'
 import {isEmpty} from 'lodash'
 
 import ConfigUtils from '../config/config-utils'
-import ProjectConfig, {RunTypeFlag, ServicesRunType} from '../config/project-config'
+import ProjectConfig, {BuildOrigin, ServicesBuildOrigin} from '../config/project-config'
 
 export default class Init extends Command {
   static description = `initialize projects config
@@ -50,15 +50,15 @@ identifier (project name) at: ~/.config/projects-config.json.
 
     // TODO validate main config
     const mainConfig = ConfigUtils.mainConfigLoad(mainConfigLocation as string)
-    const servicesRunType = {} as ServicesRunType
+    const servicesBuildOrigin = {} as ServicesBuildOrigin
 
-    mainConfig.compose.services.forEach(s => servicesRunType[s.name] = RunTypeFlag.IMAGE)
+    mainConfig.compose.services.forEach(s => servicesBuildOrigin[s.name] = BuildOrigin.REGISTRY)
 
     const projectConfig = {
       name: projectName,
       mainConfigLocation,
-      defaultRunTypeFlag: RunTypeFlag.SRC,
-      servicesRunType
+      defaultBuildOrigin: BuildOrigin.REGISTRY,
+      servicesBuildOrigin
     } as ProjectConfig
 
     ConfigUtils.projectsConfigSave({

--- a/src/commands/service/buildorigin/list.ts
+++ b/src/commands/service/buildorigin/list.ts
@@ -5,7 +5,7 @@ import BaseCommand from '../../../base-command'
 import ConfigUtils from '../../../config/config-utils'
 import {environmentFlag, servicesFlag} from '../../../wrapper/docker-compose/flags'
 
-export default class ListRunType extends BaseCommand {
+export default class BuildOriginList extends BaseCommand {
   static description = 'list service(s) runtype'
 
   static flags = {
@@ -15,7 +15,7 @@ export default class ListRunType extends BaseCommand {
   }
 
   async run() {
-    const {flags} = this.parse(ListRunType)
+    const {flags} = this.parse(BuildOriginList)
     const defaultProjectConfig = ConfigUtils.projectsConfigLoadDefault()
 
     const mainConfig = ConfigUtils.mainConfigLoad(defaultProjectConfig.mainConfigLocation)
@@ -23,11 +23,11 @@ export default class ListRunType extends BaseCommand {
     const data = [] as any
     services.forEach(s => {
       if (!flags.services || flags.services.includes(s.name)) {
-        data.push({name: s.name, runType: (defaultProjectConfig.servicesRunType[s.name] || defaultProjectConfig.defaultRunTypeFlag).toUpperCase()})
+        data.push({name: s.name, buildOrigin: (defaultProjectConfig.servicesBuildOrigin[s.name] || defaultProjectConfig.defaultBuildOrigin).toUpperCase()})
       }
     })
 
-    cli.table(data, {name: {header: 'ServiceName', minWidth: 7}, runType: {header: 'Runtype'}}, {
+    cli.table(data, {name: {header: 'ServiceName', minWidth: 7}, buildOrigin: {header: 'BuildOrigin'}}, {
       printLine: this.log
     })
   }

--- a/src/commands/service/buildorigin/set.ts
+++ b/src/commands/service/buildorigin/set.ts
@@ -2,10 +2,10 @@ import {flags} from '@oclif/command'
 
 import BaseCommand from '../../../base-command'
 import ConfigUtils from '../../../config/config-utils'
-import {RunTypeFlag} from '../../../config/project-config'
+import {BuildOrigin} from '../../../config/project-config'
 import {environmentFlag, servicesFlag} from '../../../wrapper/docker-compose/flags'
 
-export default class SetRunType extends BaseCommand {
+export default class BuildOriginSet extends BaseCommand {
   static description = 'set service(s) runtype'
 
   static flags = {
@@ -19,24 +19,24 @@ export default class SetRunType extends BaseCommand {
       name: 'value',
       required: true,
       description: 'runtype value',
-      options: [RunTypeFlag.IMAGE, RunTypeFlag.SRC]
+      options: [BuildOrigin.REGISTRY, BuildOrigin.SOURCE]
     },
   ]
 
   static examples = [
-    '$ cliw service:runtype:set image -s api'
+    '$ cliw service:buildorigin:set source -s api'
   ]
 
   async run() {
-    const {flags, args} = this.parse(SetRunType)
-    const runTypeFlag = args.value === RunTypeFlag.IMAGE.toString() ? RunTypeFlag.IMAGE : RunTypeFlag.SRC
+    const {flags, args} = this.parse(BuildOriginSet)
+    const runTypeFlag = args.value === BuildOrigin.REGISTRY.toString() ? BuildOrigin.REGISTRY : BuildOrigin.SOURCE
     const defaultProjectConfig = ConfigUtils.projectsConfigLoadDefault()
     const projectsConfig = ConfigUtils.projectsConfigLoad()
 
     projectsConfig.projects.forEach(projectConfig => {
       if (projectConfig.name === defaultProjectConfig.name) {
         flags.services.forEach(serviceName => {
-          projectConfig.servicesRunType[serviceName] = runTypeFlag
+          projectConfig.servicesBuildOrigin[serviceName] = runTypeFlag
         })
       }
     })

--- a/src/config/main-config.ts
+++ b/src/config/main-config.ts
@@ -31,9 +31,11 @@ export const enum CodeSource {
   internal, external
 }
 
-interface RunType {
-  image: string
-  src: {
+interface BuildOrigin {
+  registry: {
+    image: string
+  },
+  source: {
     build: {
       context: string
       dockerfile: string
@@ -43,12 +45,12 @@ interface RunType {
 
 interface DefaultEnvironment {
   ports: string[]
-  runType: RunType
+  buildOrigin: BuildOrigin
 }
 
 export interface Environment {
   ports?: string[]
-  runType?: RunType
+  buildOrigin: BuildOrigin
   environment?: EnvironmentVariable
 }
 

--- a/src/config/project-config.ts
+++ b/src/config/project-config.ts
@@ -1,8 +1,8 @@
 export default interface ProjectConfig {
   name: string
   mainConfigLocation: string,
-  defaultRunTypeFlag: RunTypeFlag
-  servicesRunType: ServicesRunType
+  defaultBuildOrigin: BuildOrigin
+  servicesBuildOrigin: ServicesBuildOrigin
 }
 
 export interface ServicesRunType {
@@ -11,4 +11,12 @@ export interface ServicesRunType {
 
 export const enum RunTypeFlag {
   IMAGE = 'image', SRC = 'src'
+}
+
+export interface ServicesBuildOrigin {
+  [key: string]: BuildOrigin
+}
+
+export const enum BuildOrigin {
+  SOURCE = 'source', REGISTRY = 'registry'
 }

--- a/src/wrapper/docker-compose/index.ts
+++ b/src/wrapper/docker-compose/index.ts
@@ -8,16 +8,16 @@ export default abstract class extends BaseCommand {
   dockerCompose(dryRun = false): DockerComposeWrapper {
     const mainConfig = ConfigUtils.mainConfigLoadDefault()
     const composeConfig = mainConfig.compose
-    // TODO find a better way to store and retrieve runtypes
+    // TODO find a better way to store and retrieve buildOrigin
     const projectConfig = ConfigUtils.projectsConfigLoadDefault()
-    const servicesRunType = projectConfig.servicesRunType
+    const servicesBuildOrigin = projectConfig.servicesBuildOrigin
 
     return new DockerComposeWrapper(
       composeConfig.projectName,
       composeConfig.networkName,
       composeConfig.workDir,
       composeConfig.services,
-      servicesRunType,
+      servicesBuildOrigin,
       dryRun,
       new BashWrapper({...BashWrapper.defaultOptions(), dryRun})
     )

--- a/test/commands/service/buildorigin.test.ts
+++ b/test/commands/service/buildorigin.test.ts
@@ -2,16 +2,16 @@ import {expect, test} from '@oclif/test'
 
 import {env} from '../../helper/test-helper'
 
-describe('service:runtype', () => {
+describe('service:buildorigin', () => {
   context('list', () => {
     // tslint:disable-next-line:no-multi-spaces
-    const expectedOutPut =  'ServiceName Runtype \napi         IMAGE   \ndb          IMAGE'
+    const expectedOutPut =  'ServiceName BuildOrigin \napi         REGISTRY    \ndb          REGISTRY'
 
     test
       .env(env)
       .stdout()
-      .command(['service:runtype:list'])
-      .it('lists services run-types', ctx => {
+      .command(['service:buildorigin:list'])
+      .it('lists services build origin', ctx => {
         expect(ctx.stdout).to.contain(expectedOutPut)
       })
   })

--- a/test/config/test-main-config.json
+++ b/test/config/test-main-config.json
@@ -18,7 +18,7 @@
             "ports": [
               "3000:3000"
             ],
-            "runType": {
+            "buildOrigin": {
               "source": {
                 "volumes": [
                   "./javalin-playground:/usr/src/app"
@@ -28,7 +28,9 @@
                   "dockerfile": "Dockerfile"
                 }
               },
-              "image": "kgalli/javalin-playground"
+              "registry":  {
+                "image": "kgalli/javalin-playground"
+              }
             }
           },
           "development": {
@@ -64,14 +66,16 @@
             "ports": [
               "9999:5432"
             ],
-            "runType": {
+            "buildOrigin": {
               "source": {
                 "build": {
                   "context": "./demo",
                   "dockerfile": "Dockerfile"
                 }
               },
-              "image": "postgres"
+              "registry": {
+                "image": "postgres"
+              }
             },
             "environment": {
               "POSTGRES_PASSWORD": "pg",

--- a/test/helper/projects-config-helper.ts
+++ b/test/helper/projects-config-helper.ts
@@ -1,6 +1,6 @@
 import {writeFileSync} from 'fs'
 
-import {RunTypeFlag} from '../../src/config/project-config'
+import {BuildOrigin} from '../../src/config/project-config'
 import ProjectsConfig from '../../src/config/projects-config'
 
 export function writeProjectsConfig(projectsConfigLocation: string, mainConfigLocation: string) {
@@ -9,10 +9,10 @@ export function writeProjectsConfig(projectsConfigLocation: string, mainConfigLo
     projects: [{
       name: 'test',
       mainConfigLocation,
-      defaultRunTypeFlag: RunTypeFlag.IMAGE,
-      servicesRunType: {
-        api: RunTypeFlag.IMAGE,
-        web: RunTypeFlag.IMAGE
+      defaultBuildOrigin: BuildOrigin.REGISTRY,
+      servicesBuildOrigin: {
+        api: BuildOrigin.REGISTRY,
+        web: BuildOrigin.REGISTRY
       }
     }]
   } as ProjectsConfig))


### PR DESCRIPTION
`runType` seems to be kind of wrong as we do not define how we run the container. We actually define that the image is built either from src or directly used from the docker registry.