### PR TITLE
Simplify service:buildorigin to service:origin cmd

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
       "service": {
         "description": "manage services to run as docker containers"
       },
-      "service:buildorigin": {
+      "service:origin": {
         "description": "list or set services build origin"
       },
       "project": {

--- a/src/commands/service/origin/list.ts
+++ b/src/commands/service/origin/list.ts
@@ -6,7 +6,7 @@ import ConfigUtils from '../../../config/config-utils'
 import {environmentFlag, servicesFlag} from '../../../wrapper/docker-compose/flags'
 
 export default class BuildOriginList extends BaseCommand {
-  static description = 'list service(s) runtype'
+  static description = 'list service(s) origin SOURCE|REGISTRY'
 
   static flags = {
     help: flags.help({char: 'h'}),

--- a/src/commands/service/origin/set.ts
+++ b/src/commands/service/origin/set.ts
@@ -3,41 +3,44 @@ import {flags} from '@oclif/command'
 import BaseCommand from '../../../base-command'
 import ConfigUtils from '../../../config/config-utils'
 import {BuildOrigin} from '../../../config/project-config'
-import {environmentFlag, servicesFlag} from '../../../wrapper/docker-compose/flags'
+import {environmentFlag} from '../../../wrapper/docker-compose/flags'
 
 export default class BuildOriginSet extends BaseCommand {
-  static description = 'set service(s) runtype'
+  static description = 'set service build origin SOURCE|REGISTRY'
 
   static flags = {
     help: flags.help({char: 'h'}),
-    services: {...servicesFlag, required: true},
     environment: environmentFlag,
   }
 
   static args = [
     {
+      name: 'service',
+      required: true,
+      description: 'service name'
+    },
+    {
       name: 'value',
       required: true,
-      description: 'runtype value',
+      description: 'build origin',
       options: [BuildOrigin.REGISTRY, BuildOrigin.SOURCE]
     },
   ]
 
   static examples = [
-    '$ cliw service:buildorigin:set source -s api'
+    '$ cliw service:origin:set api source'
   ]
 
   async run() {
-    const {flags, args} = this.parse(BuildOriginSet)
+    const {args} = this.parse(BuildOriginSet)
+    const serviceName = args.service
     const buildOrigin = args.value === BuildOrigin.REGISTRY.toString() ? BuildOrigin.REGISTRY : BuildOrigin.SOURCE
     const defaultProjectConfig = ConfigUtils.projectsConfigLoadDefault()
     const projectsConfig = ConfigUtils.projectsConfigLoad()
 
     projectsConfig.projects.forEach(projectConfig => {
       if (projectConfig.name === defaultProjectConfig.name) {
-        flags.services.forEach(serviceName => {
-          projectConfig.servicesBuildOrigin[serviceName] = buildOrigin
-        })
+        projectConfig.servicesBuildOrigin[serviceName] = buildOrigin
       }
     })
 

--- a/test/commands/service/origin.test.ts
+++ b/test/commands/service/origin.test.ts
@@ -2,7 +2,7 @@ import {expect, test} from '@oclif/test'
 
 import {env} from '../../helper/test-helper'
 
-describe('service:buildorigin', () => {
+describe('service:origin', () => {
   context('list', () => {
     // tslint:disable-next-line:no-multi-spaces
     const expectedOutPut =  'ServiceName BuildOrigin \napi         REGISTRY    \ndb          REGISTRY'
@@ -10,7 +10,7 @@ describe('service:buildorigin', () => {
     test
       .env(env)
       .stdout()
-      .command(['service:buildorigin:list'])
+      .command(['service:origin:list'])
       .it('lists services build origin', ctx => {
         expect(ctx.stdout).to.contain(expectedOutPut)
       })


### PR DESCRIPTION
The `service:buildorigin` command seems unnecessary long. This PR is using `service:origin` and is streamlining the input / output.

It is also not using the service as a flag -- which will probably happen for all other `service` subcommands as well.