### PR TITLE
Use argument for service name instead a flag

### DIFF
--- a/src/commands/service/build.ts
+++ b/src/commands/service/build.ts
@@ -2,21 +2,27 @@ import {flags} from '@oclif/command'
 
 import {dryRunFlag} from '../../flags'
 import DockerComposeCommand from '../../wrapper/docker-compose'
-import {environmentFlag, servicesFlag} from '../../wrapper/docker-compose/flags'
+import {servicesArg} from '../../wrapper/docker-compose/args'
+import {environmentFlag} from '../../wrapper/docker-compose/flags'
 
 export default class Build extends DockerComposeCommand {
   static description = 'build or rebuild services'
 
   static flags = {
-    services: servicesFlag,
     environment: environmentFlag,
     'dry-run': dryRunFlag,
     help: flags.help({char: 'h'})
   }
 
+  static strict = false
+
+  static args = [
+    servicesArg,
+  ]
+
   async run() {
-    const {flags} = this.parse(Build)
-    const services = flags.services
+    const {argv, flags} = this.parse(Build)
+    const services = argv
     const environment = flags.environment
     const dryRun = flags['dry-run']
 

--- a/src/commands/service/exec.ts
+++ b/src/commands/service/exec.ts
@@ -2,19 +2,20 @@ import {flags} from '@oclif/command'
 
 import {dryRunFlag} from '../../flags'
 import DockerComposeCommand from '../../wrapper/docker-compose'
-import {environmentFlag, serviceFlag} from '../../wrapper/docker-compose/flags'
+import {serviceArg} from '../../wrapper/docker-compose/args'
+import {environmentFlag} from '../../wrapper/docker-compose/flags'
 
 export default class Exec extends DockerComposeCommand {
   static description = 'execute a command in a running container'
 
   static flags = {
-    service: serviceFlag,
     environment: environmentFlag,
     'dry-run': dryRunFlag,
     help: flags.help({char: 'h'})
   }
 
   static args = [
+    serviceArg,
     {
       name: 'command',
       description: 'specify command to execute',
@@ -22,15 +23,13 @@ export default class Exec extends DockerComposeCommand {
     }
   ]
 
-  static strict = false
-
   async run() {
-    const {flags, args} = this.parse(Exec)
-    const service = flags.service
+    const {flags, args, argv} = this.parse(Exec)
+    const service = args.service
     const environment = flags.environment
     const dryRun = flags['dry-run']
 
-    const cmd = args.command
+    const cmd = argv.slice(1).join(' ')
 
     try {
       this

--- a/src/commands/service/logs.ts
+++ b/src/commands/service/logs.ts
@@ -2,13 +2,13 @@ import {flags} from '@oclif/command'
 
 import {dryRunFlag} from '../../flags'
 import DockerComposeCommand from '../../wrapper/docker-compose'
-import {environmentFlag, servicesFlag} from '../../wrapper/docker-compose/flags'
+import {servicesArg} from '../../wrapper/docker-compose/args'
+import {environmentFlag} from '../../wrapper/docker-compose/flags'
 
 export default class Logs extends DockerComposeCommand {
   static description = 'show service logs'
 
   static flags = {
-    services: servicesFlag,
     environment: environmentFlag,
     'dry-run': dryRunFlag,
     help: flags.help({char: 'h'}),
@@ -24,9 +24,15 @@ export default class Logs extends DockerComposeCommand {
     }),
   }
 
+  static strict = false
+
+  static args = [
+    servicesArg,
+  ]
+
   async run() {
-    const {flags} = this.parse(Logs)
-    const services = flags.services
+    const {argv, flags} = this.parse(Logs)
+    const services = argv
     const environment = flags.environment
     const dryRun = flags['dry-run']
     const options = {

--- a/src/commands/service/pull.ts
+++ b/src/commands/service/pull.ts
@@ -2,21 +2,27 @@ import {flags} from '@oclif/command'
 
 import {dryRunFlag} from '../../flags'
 import DockerComposeCommand from '../../wrapper/docker-compose'
-import {environmentFlag, servicesFlag} from '../../wrapper/docker-compose/flags'
+import {servicesArg} from '../../wrapper/docker-compose/args'
+import {environmentFlag} from '../../wrapper/docker-compose/flags'
 
 export default class Pull extends DockerComposeCommand {
   static description = 'pull docker image(s) from registry'
 
   static flags = {
-    services: servicesFlag,
     environment: environmentFlag,
     'dry-run': dryRunFlag,
     help: flags.help({char: 'h'}),
   }
 
+  static strict = false
+
+  static args = [
+    servicesArg,
+  ]
+
   async run() {
-    const {flags} = this.parse(Pull)
-    const services = flags.services
+    const {argv, flags} = this.parse(Pull)
+    const services = argv
     const environment = flags.environment
     const dryRun = flags['dry-run']
 

--- a/src/commands/service/restart.ts
+++ b/src/commands/service/restart.ts
@@ -2,21 +2,27 @@ import {flags} from '@oclif/command'
 
 import {dryRunFlag} from '../../flags'
 import DockerComposeCommand from '../../wrapper/docker-compose'
-import {environmentFlag, servicesFlag} from '../../wrapper/docker-compose/flags'
+import {servicesArg} from '../../wrapper/docker-compose/args'
+import {environmentFlag} from '../../wrapper/docker-compose/flags'
 
 export default class ReStart extends DockerComposeCommand {
   static description = 'stop, (re)create and start services in daemon mode'
 
   static flags = {
-    services: servicesFlag,
     environment: environmentFlag,
     'dry-run': dryRunFlag,
     help: flags.help({char: 'h'})
   }
 
+  static strict = false
+
+  static args = [
+    servicesArg,
+  ]
+
   async run() {
-    const {flags} = this.parse(ReStart)
-    const services = flags.services
+    const {argv, flags} = this.parse(ReStart)
+    const services = argv
     const environment = flags.environment
     const dryRun = flags['dry-run']
 

--- a/src/commands/service/run.ts
+++ b/src/commands/service/run.ts
@@ -2,19 +2,20 @@ import {flags} from '@oclif/command'
 
 import {dryRunFlag} from '../../flags'
 import DockerComposeCommand from '../../wrapper/docker-compose'
-import {environmentFlag, serviceFlag} from '../../wrapper/docker-compose/flags'
+import {serviceArg} from '../../wrapper/docker-compose/args'
+import {environmentFlag} from '../../wrapper/docker-compose/flags'
 
 export default class Run extends DockerComposeCommand {
   static description = 'run a one-off command on a service'
 
   static flags = {
-    service: serviceFlag,
     environment: environmentFlag,
     'dry-run': dryRunFlag,
     help: flags.help({char: 'h'})
   }
 
   static args = [
+    serviceArg,
     {
       name: 'command',
       description: 'specify command to execute',
@@ -25,11 +26,11 @@ export default class Run extends DockerComposeCommand {
   static strict = false
 
   async run() {
-    const {flags, args} = this.parse(Run)
-    const service = flags.service
+    const {flags, args, argv} = this.parse(Run)
+    const service = args.service
     const environment = flags.environment
     const dryRun = flags['dry-run']
-    const cmd = args.command
+    const cmd = argv.slice(1).join(' ')
 
     try {
       this

--- a/src/commands/service/start.ts
+++ b/src/commands/service/start.ts
@@ -2,21 +2,27 @@ import {flags} from '@oclif/command'
 
 import {dryRunFlag} from '../../flags'
 import DockerComposeCommand from '../../wrapper/docker-compose'
-import {environmentFlag, servicesFlag} from '../../wrapper/docker-compose/flags'
+import {servicesArg} from '../../wrapper/docker-compose/args'
+import {environmentFlag} from '../../wrapper/docker-compose/flags'
 
 export default class Start extends DockerComposeCommand {
   static description = '(re)create and start services in daemon mode'
 
   static flags = {
-    services: servicesFlag,
     environment: environmentFlag,
     'dry-run': dryRunFlag,
     help: flags.help({char: 'h'})
   }
 
+  static strict = false
+
+  static args = [
+    servicesArg,
+  ]
+
   async run() {
-    const {flags} = this.parse(Start)
-    const services = flags.services
+    const {argv, flags} = this.parse(Start)
+    const services = argv
     const environment = flags.environment
     const dryRun = flags['dry-run']
 

--- a/src/commands/service/status.ts
+++ b/src/commands/service/status.ts
@@ -2,6 +2,7 @@ import {flags} from '@oclif/command'
 
 import {dryRunFlag} from '../../flags'
 import DockerComposeCommand from '../../wrapper/docker-compose'
+import {servicesArg} from '../../wrapper/docker-compose/args'
 import {environmentFlag, servicesFlag} from '../../wrapper/docker-compose/flags'
 
 export default class Status extends DockerComposeCommand {
@@ -14,9 +15,15 @@ export default class Status extends DockerComposeCommand {
     help: flags.help({char: 'h'}),
   }
 
+  static strict = false
+
+  static args = [
+    servicesArg,
+  ]
+
   async run() {
-    const {flags} = this.parse(Status)
-    const services = flags.services
+    const {argv, flags} = this.parse(Status)
+    const services = argv
     const environment = flags.environment
     const dryRun = flags['dry-run']
 

--- a/src/commands/service/stop.ts
+++ b/src/commands/service/stop.ts
@@ -2,13 +2,13 @@ import {flags} from '@oclif/command'
 
 import {dryRunFlag} from '../../flags'
 import DockerComposeCommand from '../../wrapper/docker-compose'
-import {environmentFlag, servicesFlag} from '../../wrapper/docker-compose/flags'
+import {servicesArg} from '../../wrapper/docker-compose/args'
+import {environmentFlag} from '../../wrapper/docker-compose/flags'
 
 export default class Stop extends DockerComposeCommand {
   static description = 'stop services running in daemon mode'
 
   static flags = {
-    services: servicesFlag,
     environment: environmentFlag,
     'dry-run': dryRunFlag,
     help: flags.help({char: 'h'}),
@@ -19,9 +19,15 @@ export default class Stop extends DockerComposeCommand {
     })
   }
 
+  static strict = false
+
+  static args = [
+    servicesArg,
+  ]
+
   async run() {
-    const {flags} = this.parse(Stop)
-    const services = flags.services
+    const {argv, flags} = this.parse(Stop)
+    const services = argv
     const environment = flags.environment
     const dryRun = flags['dry-run']
 

--- a/src/commands/service/up.ts
+++ b/src/commands/service/up.ts
@@ -2,6 +2,7 @@ import {flags} from '@oclif/command'
 
 import {dryRunFlag} from '../../flags'
 import DockerComposeCommand from '../../wrapper/docker-compose'
+import {servicesArg} from '../../wrapper/docker-compose/args'
 import {environmentFlag, servicesFlag} from '../../wrapper/docker-compose/flags'
 
 export default class Up extends DockerComposeCommand {
@@ -14,9 +15,15 @@ export default class Up extends DockerComposeCommand {
     help: flags.help({char: 'h'}),
   }
 
+  static strict = false
+
+  static args = [
+    servicesArg,
+  ]
+
   async run() {
-    const {flags} = this.parse(Up)
-    const services = flags.services
+    const {argv, flags} = this.parse(Up)
+    const services = argv
     const environment = flags.environment
     const dryRun = flags['dry-run']
 

--- a/src/wrapper/docker-compose/args.ts
+++ b/src/wrapper/docker-compose/args.ts
@@ -1,0 +1,11 @@
+export const servicesArg = {
+  name: 'services',
+  required: false,
+  description: 'list of service names [default: all]',
+}
+
+export const serviceArg = {
+  name: 'service',
+  required: true,
+  description: 'service name',
+}

--- a/src/wrapper/docker-compose/docker-compose-wrapper.ts
+++ b/src/wrapper/docker-compose/docker-compose-wrapper.ts
@@ -53,10 +53,10 @@ export default class DockerComposeWrapper {
   }
 
   build(options: any, serviceNames: string[], environment: string) {
-    if (serviceNames) {
-      this.validate(serviceNames)
-    } else {
+    if (isEmpty(serviceNames)) {
       serviceNames = []
+    } else {
+      this.validate(serviceNames)
     }
 
     const startOptions = isEmpty(options) ? '' : options.toString()
@@ -66,10 +66,10 @@ export default class DockerComposeWrapper {
   }
 
   start(options: object, serviceNames: string[], environment: string) {
-    if (serviceNames) {
-      this.validate(serviceNames)
-    } else {
+    if (isEmpty(serviceNames)) {
       serviceNames = []
+    } else {
+      this.validate(serviceNames)
     }
 
     const startOptions = isEmpty(options) ? '' : options.toString()
@@ -81,10 +81,10 @@ export default class DockerComposeWrapper {
   }
 
   stop(options: object, serviceNames: string[], environment: string) {
-    if (serviceNames) {
-      this.validate(serviceNames)
-    } else {
+    if (isEmpty(serviceNames)) {
       serviceNames = []
+    } else {
+      this.validate(serviceNames)
     }
 
     const startOptions = isEmpty(options) ? '' : options.toString()
@@ -99,10 +99,10 @@ export default class DockerComposeWrapper {
   }
 
   up(options: object, serviceNames: string[], environment: string) {
-    if (serviceNames) {
-      this.validate(serviceNames)
-    } else {
+    if (isEmpty(serviceNames)) {
       serviceNames = []
+    } else {
+      this.validate(serviceNames)
     }
 
     const upOptions = isEmpty(options) ? '' : options.toString()
@@ -112,10 +112,10 @@ export default class DockerComposeWrapper {
   }
 
   logs(options: any, serviceNames: string[], environment: string) {
-    if (serviceNames) {
-      this.validate(serviceNames)
-    } else {
+    if (isEmpty(serviceNames)) {
       serviceNames = []
+    } else {
+      this.validate(serviceNames)
     }
 
     const logsOptions = []
@@ -153,10 +153,10 @@ export default class DockerComposeWrapper {
   }
 
   status(options: object, serviceNames: string[], environment: string) {
-    if (serviceNames) {
-      this.validate(serviceNames)
-    } else {
+    if (isEmpty(serviceNames)) {
       serviceNames = []
+    } else {
+      this.validate(serviceNames)
     }
 
     const statusOptions = isEmpty(options) ? '' : options.toString()
@@ -166,10 +166,10 @@ export default class DockerComposeWrapper {
   }
 
   pull(options: object, serviceNames: string[], environment: string) {
-    if (serviceNames) {
-      this.validate(serviceNames)
-    } else {
+    if (isEmpty(serviceNames)) {
       serviceNames = []
+    } else {
+      this.validate(serviceNames)
     }
 
     const pullOptions = isEmpty(options) ? '' : options.toString()

--- a/test/commands/service/build.test.ts
+++ b/test/commands/service/build.test.ts
@@ -6,7 +6,7 @@ describe('build', () => {
   test
     .env(env)
     .stdout()
-    .command(['service:build', '--services', 'api', '--dry-run'])
+    .command(['service:build', 'api', '--dry-run'])
     .it('invokes build with a known service', ctx => {
       expect(ctx.stdout).to.contain(expectedStdOutForCmd('build', mainConfig.compose.defaultEnvironment, []))
     })

--- a/test/commands/service/exec.test.ts
+++ b/test/commands/service/exec.test.ts
@@ -6,7 +6,7 @@ describe('exec', () => {
   test
     .env(env)
     .stdout()
-    .command(['service:exec', 'bin/bash', '--service', 'api', '--dry-run'])
+    .command(['service:exec', '--dry-run', 'api', 'bin/bash'])
     .it('invokes exec with known service', ctx => {
       expect(ctx.stdout).to.contain(expectedStdOutForCmd('exec', mainConfig.compose.defaultEnvironment, ['api', 'bin/bash']))
     })

--- a/test/commands/service/logs.test.ts
+++ b/test/commands/service/logs.test.ts
@@ -6,7 +6,7 @@ describe('logs', () => {
   test
     .env(env)
     .stdout()
-    .command(['service:logs', '--services', 'api', '--dry-run'])
+    .command(['service:logs', 'api', '--dry-run'])
     .it('invokes logs with known service', ctx => {
       expect(ctx.stdout).to.contain(expectedStdOutForCmd('logs', mainConfig.compose.defaultEnvironment, ['api']))
     })
@@ -14,7 +14,7 @@ describe('logs', () => {
   test
     .env(env)
     .stdout()
-    .command(['service:logs', '--services', 'api', '--follow', '--dry-run'])
+    .command(['service:logs', 'api', '--follow', '--dry-run'])
     .it('invokes logs with follow flag', ctx => {
       expect(ctx.stdout).to.contain(expectedStdOutForCmd('logs', mainConfig.compose.defaultEnvironment, ['--follow', 'api']))
     })
@@ -22,7 +22,7 @@ describe('logs', () => {
   test
     .env(env)
     .stdout()
-    .command(['service:logs', '--services', 'api', '--timestamps', '--dry-run'])
+    .command(['service:logs', 'api', '--timestamps', '--dry-run'])
     .it('invokes logs with timestamps flag', ctx => {
       expect(ctx.stdout).to.contain(expectedStdOutForCmd('logs', mainConfig.compose.defaultEnvironment, ['--timestamps', 'api']))
     })

--- a/test/commands/service/pull.test.ts
+++ b/test/commands/service/pull.test.ts
@@ -6,7 +6,7 @@ describe('pull', () => {
   test
     .env(env)
     .stdout()
-    .command(['service:pull', '--services', 'api', '--dry-run'])
+    .command(['service:pull', 'api', '--dry-run'])
     .it('invokes pull with known service', ctx => {
       expect(ctx.stdout).to.contain(expectedStdOutForCmd('pull', mainConfig.compose.defaultEnvironment, ['api']))
     })

--- a/test/commands/service/restart.test.ts
+++ b/test/commands/service/restart.test.ts
@@ -7,7 +7,7 @@ describe('restart', () => {
     .env(env)
     //.stdout({print: true})
     .stdout()
-    .command(['service:restart', '--services', 'api', '--dry-run'])
+    .command(['service:restart', 'api', '--dry-run'])
     .it('invokes start with known service', ctx => {
       expect(ctx.stdout).to.contain(expectedStdOutForCmd('restart', mainConfig.compose.defaultEnvironment, ['api']))
     })

--- a/test/commands/service/run.test.ts
+++ b/test/commands/service/run.test.ts
@@ -6,8 +6,8 @@ describe('run', () => {
   test
     .env(env)
     .stdout()
-    .command(['service:run', 'bin/bash', '--service', 'api', '--dry-run'])
-    .it('runs run "bin/bash" --service api', ctx => {
+    .command(['service:run', '--dry-run', 'api', 'bin/bash'])
+    .it('runs "bin/bash" command inside api', ctx => {
       expect(ctx.stdout).to.contain(expectedStdOutForCmd('run', mainConfig.compose.defaultEnvironment, ['api', 'bin/bash']))
     })
 })

--- a/test/commands/service/start.test.ts
+++ b/test/commands/service/start.test.ts
@@ -7,7 +7,7 @@ describe('start', () => {
     .env(env)
     //.stdout({print: true})
     .stdout()
-    .command(['service:start', '--services', 'api', '--dry-run'])
+    .command(['service:start', 'api', '--dry-run'])
     .it('invokes start with known service', ctx => {
       expect(ctx.stdout).to.contain(expectedStdOutForCmd('start', mainConfig.compose.defaultEnvironment, ['api']))
     })
@@ -15,7 +15,7 @@ describe('start', () => {
   test
     .env(env)
     .stdout()
-    .command(['service:start', '--services', 'demoTest', '--dry-run'])
+    .command(['service:start', 'demoTest', '--dry-run'])
     .catch(err => expect(err.message).to.match(/Expected service demoTest to be one of:/))
     .it('does not invoke start with unknown service')
 })

--- a/test/commands/service/status.test.ts
+++ b/test/commands/service/status.test.ts
@@ -6,8 +6,8 @@ describe('status', () => {
   test
     .env(env)
     .stdout()
-    .command(['service:status', '--services', 'api', '--dry-run'])
-    .it('runs status --service api', ctx => {
+    .command(['service:status', 'api', '--dry-run'])
+    .it('runs status api', ctx => {
       expect(ctx.stdout).to.contain(expectedStdOutForCmd('status', mainConfig.compose.defaultEnvironment, ['api']))
     })
 })

--- a/test/commands/service/stop.test.ts
+++ b/test/commands/service/stop.test.ts
@@ -6,8 +6,8 @@ describe('stop', () => {
   test
     .env(env)
     .stdout()
-    .command(['service:stop', '--services', 'api', '--dry-run'])
-    .it('runs stop --service api', ctx => {
+    .command(['service:stop', 'api', '--dry-run'])
+    .it('runs stop api', ctx => {
       expect(ctx.stdout).to.contain(expectedStdOutForCmd('stop', mainConfig.compose.defaultEnvironment, ['api']))
     })
 })

--- a/test/commands/service/up.test.ts
+++ b/test/commands/service/up.test.ts
@@ -6,8 +6,8 @@ describe('up', () => {
   test
     .env(env)
     .stdout()
-    .command(['service:up', '--services', 'api', '--dry-run'])
-    .it('runs up --service api', ctx => {
+    .command(['service:up', 'api', '--dry-run'])
+    .it('runs up api', ctx => {
       expect(ctx.stdout).to.contain(expectedStdOutForCmd('up', mainConfig.compose.defaultEnvironment, ['api']))
     })
 })


### PR DESCRIPTION
Service should be an argument as it is more idiomatic for a CLI to require arguments instead of options.