### PR TITLE
Use first argument to specify datasource to ease usage

### DIFF
--- a/src/commands/db/console.ts
+++ b/src/commands/db/console.ts
@@ -2,28 +2,32 @@ import {flags} from '@oclif/command'
 
 import {dryRunFlag} from '../../flags'
 import DbToolsWrapper from '../../wrapper/db-tools'
-import {connectionFlag, environmentFlag} from '../../wrapper/db-tools/flags'
+import {dataSourceNameArg} from '../../wrapper/db-tools/args'
+import {environmentFlag} from '../../wrapper/db-tools/flags'
 
 export default class Console extends DbToolsWrapper {
   static description = 'run database console'
 
   static flags = {
-    service: connectionFlag,
     environment: environmentFlag,
     'dry-run': dryRunFlag,
     help: flags.help({char: 'h'})
   }
 
+  static args = [
+    dataSourceNameArg
+  ]
+
   async run() {
-    const {flags} = this.parse(Console)
-    const service = flags.service
+    const {args, flags} = this.parse(Console)
+    const dataSource = args.datasource
     const environment = flags.environment
     const dryRun = flags['dry-run']
 
     try {
       await this
         .dbTools(dryRun)
-        .console({}, service, environment)
+        .console({}, dataSource, environment)
     } catch (e) {
       this.error(e.message, e)
     }

--- a/src/commands/db/create.ts
+++ b/src/commands/db/create.ts
@@ -2,28 +2,32 @@ import {flags} from '@oclif/command'
 
 import {dryRunFlag} from '../../flags'
 import DbToolsWrapper from '../../wrapper/db-tools'
-import {connectionFlag, environmentFlag} from '../../wrapper/db-tools/flags'
+import {dataSourceNameArg} from '../../wrapper/db-tools/args'
+import {environmentFlag} from '../../wrapper/db-tools/flags'
 
 export default class Create extends DbToolsWrapper {
   static description = 'create database'
 
   static flags = {
-    service: connectionFlag,
     environment: environmentFlag,
     'dry-run': dryRunFlag,
     help: flags.help({char: 'h'})
   }
 
+  static args = [
+    dataSourceNameArg
+  ]
+
   async run() {
-    const {flags} = this.parse(Create)
-    const service = flags.service
+    const {args, flags} = this.parse(Create)
+    const datasource = args.datasource
     const environment = flags.environment
     const dryRun = flags['dry-run']
 
     try {
       await this
         .dbTools(dryRun)
-        .create(service, environment)
+        .create(datasource, environment)
     } catch (e) {
       this.error(e.message, e)
     }

--- a/src/commands/db/drop.ts
+++ b/src/commands/db/drop.ts
@@ -2,28 +2,32 @@ import {flags} from '@oclif/command'
 
 import {dryRunFlag} from '../../flags'
 import DbToolsWrapper from '../../wrapper/db-tools'
-import {connectionFlag, environmentFlag} from '../../wrapper/db-tools/flags'
+import {dataSourceNameArg} from '../../wrapper/db-tools/args'
+import {environmentFlag} from '../../wrapper/db-tools/flags'
 
 export default class Drop extends DbToolsWrapper {
   static description = 'create database'
 
   static flags = {
-    service: connectionFlag,
     environment: environmentFlag,
     'dry-run': dryRunFlag,
     help: flags.help({char: 'h'})
   }
 
+  static args = [
+    dataSourceNameArg
+  ]
+
   async run() {
-    const {flags} = this.parse(Drop)
-    const service = flags.service
+    const {args, flags} = this.parse(Drop)
+    const datasource = args.datasource
     const environment = flags.environment
     const dryRun = flags['dry-run']
 
     try {
       await this
         .dbTools(dryRun)
-        .drop(service, environment)
+        .drop(datasource, environment)
     } catch (e) {
       this.error(e.message, e)
     }

--- a/src/commands/db/dump.ts
+++ b/src/commands/db/dump.ts
@@ -2,14 +2,14 @@ import {flags} from '@oclif/command'
 
 import {dryRunFlag} from '../../flags'
 import DbToolsWrapper from '../../wrapper/db-tools'
-import {connectionFlag, environmentFlag} from '../../wrapper/db-tools/flags'
+import {dataSourceNameArg} from '../../wrapper/db-tools/args'
+import {environmentFlag} from '../../wrapper/db-tools/flags'
 import PgdumpOptions from '../../wrapper/db-tools/pgdump-options'
 
 export default class Dump extends DbToolsWrapper {
   static description = 'create database'
 
   static flags = {
-    service: connectionFlag,
     environment: environmentFlag,
     'dry-run': dryRunFlag,
     'schema-only': flags.boolean({
@@ -26,9 +26,13 @@ export default class Dump extends DbToolsWrapper {
     help: flags.help({char: 'h'})
   }
 
+  static args = [
+    dataSourceNameArg
+  ]
+
   async run() {
-    const {flags} = this.parse(Dump)
-    const service = flags.service
+    const {args, flags} = this.parse(Dump)
+    const service = args.datasource
     const environment = flags.environment
     const dryRun = flags['dry-run']
     const options: PgdumpOptions = {

--- a/src/commands/db/restore.ts
+++ b/src/commands/db/restore.ts
@@ -2,14 +2,14 @@ import {flags} from '@oclif/command'
 
 import {dryRunFlag} from '../../flags'
 import DbToolsWrapper from '../../wrapper/db-tools'
-import {connectionFlag, environmentFlag} from '../../wrapper/db-tools/flags'
+import {dataSourceNameArg} from '../../wrapper/db-tools/args'
+import {environmentFlag} from '../../wrapper/db-tools/flags'
 import PgrestoreOptions from '../../wrapper/db-tools/pgrestore-options'
 
 export default class Restore extends DbToolsWrapper {
   static description = 'restore database'
 
   static flags = {
-    service: connectionFlag,
     environment: environmentFlag,
     'dry-run': dryRunFlag,
     'restore-file': flags.string({
@@ -21,9 +21,13 @@ export default class Restore extends DbToolsWrapper {
     help: flags.help({char: 'h'})
   }
 
+  static args = [
+    dataSourceNameArg
+  ]
+
   async run() {
-    const {flags} = this.parse(Restore)
-    const service = flags.service
+    const {args, flags} = this.parse(Restore)
+    const service = args.datasource
     const environment = flags.environment
     const restoreFileLocation = flags['restore-file']
     const dryRun = flags['dry-run']

--- a/src/wrapper/db-tools/args.ts
+++ b/src/wrapper/db-tools/args.ts
@@ -1,0 +1,5 @@
+export const dataSourceNameArg = {
+  name: 'datasource',
+  required: true,
+  description: 'data source specified by name',
+}

--- a/test/commands/db/console.test.ts
+++ b/test/commands/db/console.test.ts
@@ -6,7 +6,7 @@ describe('db:console', () => {
   test
     .env(env)
     .stdout()
-    .command(['db:console', '--service', 'api', '--dry-run'])
+    .command(['db:console', 'api', '--dry-run'])
     .it('invokes docker cmd to open a console', ctx => {
       const expectedOutput = 'docker run --rm -it --net=host -e PGPASSWORD=kgalli_pw -v $PWD:/opt -w /opt postgres psql -h 127.0.0.1 -p 5436 -U kgalli_us -d kgalli_db'
 

--- a/test/commands/db/create.test.ts
+++ b/test/commands/db/create.test.ts
@@ -6,7 +6,7 @@ describe('db:create', () => {
   test
     .env(env)
     .stdout()
-    .command(['db:create', '--service', 'api', '--dry-run'])
+    .command(['db:create', 'api', '--dry-run'])
     .it('invokes docker cmd to create database', ctx => {
       const expectedOutput = 'docker run --rm -it --net=host -e PGPASSWORD=kgalli_pw -v $PWD:/opt -w /opt postgres psql -h 127.0.0.1 -p 5436 -U kgalli_us -d template1 -c "CREATE DATABASE kgalli_db WITH OWNER kgalli_us ENCODING \'UTF8\' LC_COLLATE = \'en_US.utf8\' LC_CTYPE = \'en_US.utf8\';"'
 
@@ -16,7 +16,7 @@ describe('db:create', () => {
   test
     .env(env)
     .stdout()
-    .command(['db:create', '--service', 'api', '--environment', 'production', '--dry-run'])
+    .command(['db:create', 'api', '--environment', 'production', '--dry-run'])
     .catch(err => expect(err.message).to.match(/Command "create" is not supported in a readonly connection/))
     .it('raises an error due to readonly data source')
 })

--- a/test/commands/db/drop.test.ts
+++ b/test/commands/db/drop.test.ts
@@ -6,7 +6,7 @@ describe('db:drop', () => {
   test
     .env(env)
     .stdout()
-    .command(['db:drop', '--service', 'api', '--dry-run'])
+    .command(['db:drop', 'api', '--dry-run'])
     .it('invokes docker cmd to drop database', ctx => {
       const expectedOutput = 'docker run --rm -it --net=host -e PGPASSWORD=kgalli_pw -v $PWD:/opt -w /opt postgres psql -h 127.0.0.1 -p 5436 -U kgalli_us -d template1 -c "DROP DATABASE IF EXISTS kgalli_db;"'
 
@@ -16,7 +16,7 @@ describe('db:drop', () => {
   test
     .env(env)
     .stdout()
-    .command(['db:drop', '--service', 'api', '--environment', 'production', '--dry-run'])
+    .command(['db:drop', 'api', '--environment', 'production', '--dry-run'])
     .catch(err => expect(err.message).to.match(/Command "drop" is not supported in a readonly connection/))
     .it('raises an error due to readonly data source')
 })

--- a/test/commands/db/dump.test.ts
+++ b/test/commands/db/dump.test.ts
@@ -6,7 +6,7 @@ describe('db:dump', () => {
   test
     .env(env)
     .stdout()
-    .command(['db:dump', '--service', 'api', '-t', 'kgalli-development.dump', '--dry-run'])
+    .command(['db:dump', 'api', '-t', 'kgalli-development.dump', '--dry-run'])
     .it('invokes docker cmd to dump database', ctx => {
       const expectedOutput = 'docker run --rm -it --net=host -e PGPASSWORD=kgalli_pw -v $PWD:/opt -w /opt postgres pg_dump -h 127.0.0.1 -p 5436 -U kgalli_us --verbose --no-security-labels --no-owner --if-exists --clean --no-tablespaces --no-privileges --format=custom --file kgalli-development.dump -d kgalli_db'
 

--- a/test/commands/db/restore.test.ts
+++ b/test/commands/db/restore.test.ts
@@ -6,7 +6,7 @@ describe('db:restore', () => {
   test
     .env(env)
     .stdout()
-    .command(['db:restore', '--service', 'api', '-r', 'kgalli-development.dump', '--dry-run'])
+    .command(['db:restore', 'api', '-r', 'kgalli-development.dump', '--dry-run'])
     .it('invokes docker command to restore database', ctx => {
       const expectedOutput = 'docker run --rm -it --net=host -e PGPASSWORD=kgalli_pw -v $PWD:/opt -w /opt postgres pg_restore -h 127.0.0.1 -p 5436 -U kgalli_us --verbose --no-owner --no-privileges --format=custom -d kgalli_db kgalli-development.dump'
 
@@ -16,7 +16,7 @@ describe('db:restore', () => {
   test
     .env(env)
     .stdout()
-    .command(['db:restore', '--service', 'api', '--environment', 'production', '-r', 'kgalli-development.dump', '--dry-run'])
+    .command(['db:restore', 'api', '--environment', 'production', '-r', 'kgalli-development.dump', '--dry-run'])
     .catch(err => expect(err.message).to.match(/Command "restore" is not supported in a readonly connection/))
     .it('raises an error due to readonly data source')
 })


### PR DESCRIPTION
As we already use the first argument to define service(s) when using the `service` subcommand it feels cleaner to do this for all subcommands -- hence also for `db`.