### PR TITLE
Use first argument to specify project to ease usage

### DIFF
--- a/src/commands/project/add.ts
+++ b/src/commands/project/add.ts
@@ -8,11 +8,6 @@ export default class ProjectAdd extends BaseCommand {
   static description = 'add project'
 
   static flags = {
-    name: flags.string({
-      char: 'n',
-      required: true,
-      description: 'name used as identifier for project'
-    }),
     config: flags.string({
       char: 'c',
       required: true,
@@ -21,9 +16,17 @@ export default class ProjectAdd extends BaseCommand {
     help: flags.help({char: 'h'})
   }
 
+  static args = [
+    {
+      name: 'project',
+      required: true,
+      description: 'project specified by name'
+    }
+  ]
+
   async run() {
-    const {flags} = this.parse(ProjectAdd)
-    const projectName = flags.name
+    const {args, flags} = this.parse(ProjectAdd)
+    const projectName = args.project
     const mainConfigLocation = flags.config
     const projectsConfig = ConfigUtils.projectsConfigLoad()
 

--- a/src/commands/project/remove.ts
+++ b/src/commands/project/remove.ts
@@ -9,17 +9,19 @@ export default class ProjectRemove extends BaseCommand {
   static description = 'remove project'
 
   static flags = {
-    name: flags.string({
-      char: 'n',
-      required: true,
-      description: 'name used as identifier for project'
-    }),
     help: flags.help({char: 'h'})
   }
+  static args = [
+    {
+      name: 'project',
+      required: true,
+      description: 'project specified by name'
+    }
+  ]
 
   async run() {
-    const {flags} = this.parse(ProjectRemove)
-    const projectToRemoveName = flags.name
+    const {args} = this.parse(ProjectRemove)
+    const projectToRemoveName = args.project
     const defaultProjectsConfig = ConfigUtils.projectsConfigLoadDefault()
     const projectsConfig = ConfigUtils.projectsConfigLoad()
 

--- a/src/commands/project/set-default.ts
+++ b/src/commands/project/set-default.ts
@@ -7,17 +7,20 @@ export default class ProjectSetDefault extends BaseCommand {
   static description = 'set default project'
 
   static flags = {
-    name: flags.string({
-      char: 'n',
-      required: true,
-      description: 'name used as identifier for project'
-    }),
     help: flags.help({char: 'h'})
   }
 
+  static args = [
+    {
+      name: 'project',
+      required: true,
+      description: 'project specified by name'
+    }
+  ]
+
   async run() {
-    const {flags} = this.parse(ProjectSetDefault)
-    const projectName = flags.name
+    const {args} = this.parse(ProjectSetDefault)
+    const projectName = args.project
     const projectsConfig = ConfigUtils.projectsConfigLoad()
     const projectExists = projectsConfig.projects
       .map(project => project.name)

--- a/test/commands/project.test.ts
+++ b/test/commands/project.test.ts
@@ -37,7 +37,7 @@ describe('project', () => {
       .env(env)
       .stdout()
       .do(() => writeProjectsConfig(TEST_PROJECTS_CONFIG_LOCATION, TEST_MAIN_CONFIG_LOCATION))
-      .command(['project:add', '-n', 'project1', '-c', TEST_MAIN_CONFIG_LOCATION])
+      .command(['project:add', 'project1', '-c', TEST_MAIN_CONFIG_LOCATION])
       .command(['project:list', '--csv'])
       .it('adds the project', ctx => {
         const csvOutput = ctx.stdout.split('\n')
@@ -66,8 +66,8 @@ describe('project', () => {
       .env(env)
       .stdout()
       .do(() => writeProjectsConfig(TEST_PROJECTS_CONFIG_LOCATION, TEST_MAIN_CONFIG_LOCATION))
-      .command(['project:add', '-n', 'project1', '-c', TEST_MAIN_CONFIG_LOCATION])
-      .command(['project:remove', '-n', 'project1'])
+      .command(['project:add', 'project1', '-c', TEST_MAIN_CONFIG_LOCATION])
+      .command(['project:remove', 'project1'])
       .command(['project:list', '--csv'])
       .it('removes the project', ctx => {
         const csvOutput = ctx.stdout.split('\n')
@@ -90,8 +90,8 @@ describe('project', () => {
       .env(env)
       .stdout()
       .do(() => writeProjectsConfig(TEST_PROJECTS_CONFIG_LOCATION, TEST_MAIN_CONFIG_LOCATION))
-      .command(['project:add', '-n', 'project1', '-c', TEST_MAIN_CONFIG_LOCATION])
-      .command(['project:set-default', '-n', 'project1'])
+      .command(['project:add', 'project1', '-c', TEST_MAIN_CONFIG_LOCATION])
+      .command(['project:set-default', 'project1'])
       .command(['project:list', '--csv'])
       .it('sets the default project', ctx => {
         const csvOutput = ctx.stdout.split('\n')


### PR DESCRIPTION
As we already use the first argument to define service(s) when using the `service` or `db` subcommand it feels cleaner to do this for all subcommands -- hence also for `project`.