### PR TITLE
Make workdir a project config

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -21,7 +21,11 @@ identifier (project name) at: ~/.config/projects-config.json.
     }),
     mainConfig: flags.string({
       char: 'm',
-      description: 'location of the main-config.json file'
+      description: 'absolute location of the main-config.json file'
+    }),
+    workDir: flags.string({
+      char: 'w',
+      description: 'absolute location of the working directory'
     }),
     help: flags.help({char: 'h'})
   }
@@ -48,6 +52,14 @@ identifier (project name) at: ~/.config/projects-config.json.
       this.error('MainConfig could not be found with the provided location')
     }
 
+    let workDirLocation = flags.workDir
+    if (isEmpty(flags.workDir)) {
+      workDirLocation = await cli.prompt('Please enter the absolute path to your working directory')
+    }
+
+    if (!ConfigUtils.exists(workDirLocation as string)) {
+      this.error('Working directory could not be found with at the provided location')
+    }
     // TODO validate main config
     const mainConfig = ConfigUtils.mainConfigLoad(mainConfigLocation as string)
     const servicesBuildOrigin = {} as ServicesBuildOrigin
@@ -56,6 +68,7 @@ identifier (project name) at: ~/.config/projects-config.json.
 
     const projectConfig = {
       name: projectName,
+      workDir: workDirLocation,
       mainConfigLocation,
       defaultBuildOrigin: BuildOrigin.REGISTRY,
       servicesBuildOrigin

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -17,13 +17,13 @@ identifier (project name) at: ~/.config/projects-config.json.
   static flags = {
     name: flags.string({
       char: 'n',
-      description: 'name used as identifier for project'
+      description: 'project unique identifier (name)'
     }),
-    mainConfig: flags.string({
-      char: 'm',
-      description: 'absolute location of the main-config.json file'
+    config: flags.string({
+      char: 'c',
+      description: 'location of the configuration file (*.json)'
     }),
-    workDir: flags.string({
+    'working-directory': flags.string({
       char: 'w',
       description: 'absolute location of the working directory'
     }),
@@ -34,7 +34,7 @@ identifier (project name) at: ~/.config/projects-config.json.
     const {flags} = this.parse(Init)
 
     if (ConfigUtils.projectsConfigExists()) {
-      this.log('Init config already exists')
+      this.log('Initial project already exists. Use `cliw project:list` command for details')
       return
     }
 
@@ -43,8 +43,8 @@ identifier (project name) at: ~/.config/projects-config.json.
       projectName = await cli.prompt('Please enter the project name')
     }
 
-    let mainConfigLocation = flags.mainConfig
-    if (isEmpty(flags.mainConfig)) {
+    let mainConfigLocation = flags.config
+    if (isEmpty(flags.config)) {
       mainConfigLocation = await cli.prompt('Please enter the location of your <main-config>.json file')
     }
 
@@ -52,8 +52,8 @@ identifier (project name) at: ~/.config/projects-config.json.
       this.error('MainConfig could not be found with the provided location')
     }
 
-    let workDirLocation = flags.workDir
-    if (isEmpty(flags.workDir)) {
+    let workDirLocation = flags['working-directory']
+    if (isEmpty(flags['working-directory'])) {
       workDirLocation = await cli.prompt('Please enter the absolute path to your working directory')
     }
 

--- a/src/commands/project/add.ts
+++ b/src/commands/project/add.ts
@@ -13,6 +13,11 @@ export default class ProjectAdd extends BaseCommand {
       required: true,
       description: 'location of the configuration file (*.json)'
     }),
+    'working-directory': flags.string({
+      char: 'w',
+      required: true,
+      description: 'absolute location of the working directory'
+    }),
     help: flags.help({char: 'h'})
   }
 
@@ -28,10 +33,15 @@ export default class ProjectAdd extends BaseCommand {
     const {args, flags} = this.parse(ProjectAdd)
     const projectName = args.project
     const mainConfigLocation = flags.config
+    const workDir = flags['working-directory']
     const projectsConfig = ConfigUtils.projectsConfigLoad()
 
     if (!ConfigUtils.exists(mainConfigLocation as string)) {
       this.error('MainConfig could not be found with the provided location')
+    }
+
+    if (!ConfigUtils.exists(workDir as string)) {
+      this.error(`Working directory could not be found at ${workDir}`)
     }
 
     const mainConfig = ConfigUtils.mainConfigLoad(mainConfigLocation as string)
@@ -41,6 +51,7 @@ export default class ProjectAdd extends BaseCommand {
 
     const projectConfig = {
       name: projectName,
+      workDir,
       mainConfigLocation,
       defaultBuildOrigin: BuildOrigin.REGISTRY,
       servicesBuildOrigin

--- a/src/commands/project/list.ts
+++ b/src/commands/project/list.ts
@@ -30,6 +30,7 @@ export default class ProjectList extends BaseCommand {
       name: {
         minWidth: 7,
       },
+      workDir: {},
       mainConfigLocation: {},
       default: {
         get: row => row.name === projectsConfig.default ? true : ''

--- a/src/config/main-config.ts
+++ b/src/config/main-config.ts
@@ -2,7 +2,6 @@ import DataSource from './data-source'
 
 export interface MainConfig {
   compose: {
-    workDir: string
     projectName: string
     networkName: string
     environments: string[],

--- a/src/config/project-config.ts
+++ b/src/config/project-config.ts
@@ -1,6 +1,7 @@
 export default interface ProjectConfig {
   name: string
-  mainConfigLocation: string,
+  workDir: string
+  mainConfigLocation: string
   defaultBuildOrigin: BuildOrigin
   servicesBuildOrigin: ServicesBuildOrigin
 }

--- a/src/wrapper/docker-compose/index.ts
+++ b/src/wrapper/docker-compose/index.ts
@@ -15,7 +15,7 @@ export default abstract class extends BaseCommand {
     return new DockerComposeWrapper(
       composeConfig.projectName,
       composeConfig.networkName,
-      composeConfig.workDir,
+      projectConfig.workDir,
       composeConfig.services,
       servicesBuildOrigin,
       dryRun,

--- a/test/commands/project.test.ts
+++ b/test/commands/project.test.ts
@@ -4,6 +4,7 @@ import {writeProjectsConfig} from '../helper/projects-config-helper'
 
 const TEST_PROJECTS_CONFIG_LOCATION = `${__dirname}/../config/test-projects-config.json`
 const TEST_MAIN_CONFIG_LOCATION = `${__dirname}/../config/test-main-config.json`
+const TEST_WORKDIR_LOCATION = '/tmp'
 const env = {CLIW_PROJECT_CONFIG_LOCATION: TEST_PROJECTS_CONFIG_LOCATION, TEST_OUTPUT: '0'}
 
 describe('project', () => {
@@ -11,21 +12,24 @@ describe('project', () => {
     test
       .env(env)
       .stdout()
-      .do(() => writeProjectsConfig(TEST_PROJECTS_CONFIG_LOCATION, TEST_MAIN_CONFIG_LOCATION))
+      .do(() => writeProjectsConfig(TEST_PROJECTS_CONFIG_LOCATION, TEST_MAIN_CONFIG_LOCATION, TEST_WORKDIR_LOCATION))
       .command(['project:list', '--csv'])
       .it('lists projects', ctx => {
         const csvOutput = ctx.stdout.split('\n')
         // header
         const header = csvOutput[0]
-        expect(header).to.contain('Name,Mainconfiglocation,Default')
+        expect(header).to.contain('Name,Workdir,Mainconfiglocation,Default')
         // project column
         const firstProject = csvOutput[1].split(',')[0]
         expect(firstProject).to.eql('test')
+        // working directory location column
+        const firstWorkDirLocation = csvOutput[1].split(',')[1]
+        expect(firstWorkDirLocation).to.eql(TEST_WORKDIR_LOCATION)
         // main config location column
-        const firstMainConfigLocation = csvOutput[1].split(',')[1]
+        const firstMainConfigLocation = csvOutput[1].split(',')[2]
         expect(firstMainConfigLocation).to.eql(TEST_MAIN_CONFIG_LOCATION)
         // default project column
-        const firstProjectDefault = csvOutput[1].split(',')[2]
+        const firstProjectDefault = csvOutput[1].split(',')[3]
         expect(firstProjectDefault).to.eql('true')
         // only one project in list
         expect(csvOutput.length).to.eql(3)
@@ -36,8 +40,8 @@ describe('project', () => {
     test
       .env(env)
       .stdout()
-      .do(() => writeProjectsConfig(TEST_PROJECTS_CONFIG_LOCATION, TEST_MAIN_CONFIG_LOCATION))
-      .command(['project:add', 'project1', '-c', TEST_MAIN_CONFIG_LOCATION])
+      .do(() => writeProjectsConfig(TEST_PROJECTS_CONFIG_LOCATION, TEST_MAIN_CONFIG_LOCATION, TEST_WORKDIR_LOCATION))
+      .command(['project:add', 'project1', '-c', TEST_MAIN_CONFIG_LOCATION, '-w', TEST_WORKDIR_LOCATION])
       .command(['project:list', '--csv'])
       .it('adds the project', ctx => {
         const csvOutput = ctx.stdout.split('\n')
@@ -46,14 +50,19 @@ describe('project', () => {
         const secondProject = csvOutput[2].split(',')[0]
         expect(firstProject).to.eql('project1')
         expect(secondProject).to.eql('test')
+        // working directory location column
+        const firstWorkDirLocation = csvOutput[1].split(',')[1]
+        const secondWorkDirLocation = csvOutput[1].split(',')[1]
+        expect(firstWorkDirLocation).to.eql(TEST_WORKDIR_LOCATION)
+        expect(secondWorkDirLocation).to.eql(TEST_WORKDIR_LOCATION)
         // main config location column
-        const firstMainConfigLocation = csvOutput[1].split(',')[1]
-        const secondMainConfigLocation = csvOutput[2].split(',')[1]
+        const firstMainConfigLocation = csvOutput[1].split(',')[2]
+        const secondMainConfigLocation = csvOutput[2].split(',')[2]
         expect(firstMainConfigLocation).to.eql(TEST_MAIN_CONFIG_LOCATION)
         expect(secondMainConfigLocation).to.eql(TEST_MAIN_CONFIG_LOCATION)
         // default project column
-        const firstProjectDefault = csvOutput[1].split(',')[2]
-        const secondProjectDefault = csvOutput[2].split(',')[2]
+        const firstProjectDefault = csvOutput[1].split(',')[3]
+        const secondProjectDefault = csvOutput[2].split(',')[3]
         expect(firstProjectDefault).to.eql('')
         expect(secondProjectDefault).to.eql('true')
         // two projects in list
@@ -65,8 +74,8 @@ describe('project', () => {
     test
       .env(env)
       .stdout()
-      .do(() => writeProjectsConfig(TEST_PROJECTS_CONFIG_LOCATION, TEST_MAIN_CONFIG_LOCATION))
-      .command(['project:add', 'project1', '-c', TEST_MAIN_CONFIG_LOCATION])
+      .do(() => writeProjectsConfig(TEST_PROJECTS_CONFIG_LOCATION, TEST_MAIN_CONFIG_LOCATION, TEST_WORKDIR_LOCATION))
+      .command(['project:add', 'project1', '-c', TEST_MAIN_CONFIG_LOCATION, '-w', TEST_WORKDIR_LOCATION])
       .command(['project:remove', 'project1'])
       .command(['project:list', '--csv'])
       .it('removes the project', ctx => {
@@ -75,10 +84,10 @@ describe('project', () => {
         const firstProject = csvOutput[1].split(',')[0]
         expect(firstProject).to.eql('test')
         // main config location column
-        const firstMainConfigLocation = csvOutput[1].split(',')[1]
+        const firstMainConfigLocation = csvOutput[1].split(',')[2]
         expect(firstMainConfigLocation).to.eql(TEST_MAIN_CONFIG_LOCATION)
         // default project column
-        const firstProjectDefault = csvOutput[1].split(',')[2]
+        const firstProjectDefault = csvOutput[1].split(',')[3]
         expect(firstProjectDefault).to.eql('true')
         // only one project in list
         expect(csvOutput.length).to.eql(3)
@@ -89,8 +98,8 @@ describe('project', () => {
     test
       .env(env)
       .stdout()
-      .do(() => writeProjectsConfig(TEST_PROJECTS_CONFIG_LOCATION, TEST_MAIN_CONFIG_LOCATION))
-      .command(['project:add', 'project1', '-c', TEST_MAIN_CONFIG_LOCATION])
+      .do(() => writeProjectsConfig(TEST_PROJECTS_CONFIG_LOCATION, TEST_MAIN_CONFIG_LOCATION, TEST_WORKDIR_LOCATION))
+      .command(['project:add', 'project1', '-c', TEST_MAIN_CONFIG_LOCATION, '-w', TEST_WORKDIR_LOCATION])
       .command(['project:set-default', 'project1'])
       .command(['project:list', '--csv'])
       .it('sets the default project', ctx => {
@@ -101,13 +110,13 @@ describe('project', () => {
         expect(firstProject).to.eql('project1')
         expect(secondProject).to.eql('test')
         // main config location column
-        const firstMainConfigLocation = csvOutput[1].split(',')[1]
-        const secondMainConfigLocation = csvOutput[2].split(',')[1]
+        const firstMainConfigLocation = csvOutput[1].split(',')[2]
+        const secondMainConfigLocation = csvOutput[2].split(',')[2]
         expect(firstMainConfigLocation).to.eql(TEST_MAIN_CONFIG_LOCATION)
         expect(secondMainConfigLocation).to.eql(TEST_MAIN_CONFIG_LOCATION)
         // default project column
-        const firstProjectDefault = csvOutput[1].split(',')[2]
-        const secondProjectDefault = csvOutput[2].split(',')[2]
+        const firstProjectDefault = csvOutput[1].split(',')[3]
+        const secondProjectDefault = csvOutput[2].split(',')[3]
         expect(firstProjectDefault).to.eql('true')
         expect(secondProjectDefault).to.eql('')
         // two projects in list

--- a/test/config/test-main-config.json
+++ b/test/config/test-main-config.json
@@ -1,6 +1,5 @@
 {
   "compose": {
-    "workDir": "/Users/kgallinowsk/dev",
     "projectName": "cliw",
     "networkName": "cliw",
     "defaultEnvironment": "development",

--- a/test/helper/projects-config-helper.ts
+++ b/test/helper/projects-config-helper.ts
@@ -3,12 +3,15 @@ import {writeFileSync} from 'fs'
 import {BuildOrigin} from '../../src/config/project-config'
 import ProjectsConfig from '../../src/config/projects-config'
 
-export function writeProjectsConfig(projectsConfigLocation: string, mainConfigLocation: string) {
+export function writeProjectsConfig(projectsConfigLocation: string,
+                                    mainConfigLocation: string,
+                                    workDir: string) {
   writeFileSync(projectsConfigLocation, JSON.stringify({
     default: 'test',
     projects: [
       {
         name: 'test',
+        workDir,
         mainConfigLocation,
         defaultBuildOrigin: BuildOrigin.REGISTRY,
         servicesBuildOrigin: {

--- a/test/helper/test-helper.ts
+++ b/test/helper/test-helper.ts
@@ -6,13 +6,14 @@ import {writeProjectsConfig} from './projects-config-helper'
 
 const TEST_PROJECTS_CONFIG_LOCATION = `${__dirname}/../config/test-projects-config.json`
 const TEST_MAIN_CONFIG_LOCATION = `${__dirname}/../config/test-main-config.json`
+const TEST_WORK_DIR_LOCATION = '/tmp'
 
-writeProjectsConfig(TEST_PROJECTS_CONFIG_LOCATION, TEST_MAIN_CONFIG_LOCATION)
+writeProjectsConfig(TEST_PROJECTS_CONFIG_LOCATION, TEST_MAIN_CONFIG_LOCATION, TEST_WORK_DIR_LOCATION)
 
 // set TEST_OUTPUT: '1' to see console.log statements in tests
 const env = {CLIW_PROJECT_CONFIG_LOCATION: TEST_PROJECTS_CONFIG_LOCATION, TEST_OUTPUT: '0'}
 
 const mainConfig: MainConfig = loadMainConfig(TEST_MAIN_CONFIG_LOCATION)
-const expectedStdOutForCmd = stdOutHelperForDockerComposeCmd(mainConfig.compose.projectName, mainConfig.compose.workDir)
+const expectedStdOutForCmd = stdOutHelperForDockerComposeCmd(mainConfig.compose.projectName, TEST_WORK_DIR_LOCATION)
 
 export {mainConfig, expectedStdOutForCmd, env}


### PR DESCRIPTION
It seems reasonable to make the `workdir` a project config property even though it is only used by the `DockerComposeWrapper`. `workdir` is an dynamic value and having it in the main config leads to issue when a config file is shared between a team.

Overall not optimal but I think still better this way than the other way around.