### PR TITLE
Disable dollar quoting to get around import issues

### DIFF
--- a/src/wrapper/db-tools/postgre-sql.ts
+++ b/src/wrapper/db-tools/postgre-sql.ts
@@ -42,7 +42,7 @@ export default class PostgreSql {
     cmd.push(`-h ${connectionParams.host}`)
     cmd.push(`-p ${connectionParams.port}`)
     cmd.push(`-U ${connectionParams.user}`)
-    cmd.push('--verbose --no-security-labels --no-owner --if-exists --clean --no-tablespaces --no-privileges')
+    cmd.push('--verbose --no-security-labels --no-owner --if-exists --clean --no-tablespaces --no-privileges --disable-dollar-quoting')
 
     if (options.schemaOnly) {
       cmd.push('--schema-only')

--- a/test/commands/db/dump.test.ts
+++ b/test/commands/db/dump.test.ts
@@ -8,7 +8,7 @@ describe('db:dump', () => {
     .stdout()
     .command(['db:dump', 'api', '-t', 'kgalli-development.dump', '--dry-run'])
     .it('invokes docker cmd to dump database', ctx => {
-      const expectedOutput = 'docker run --rm -it --net=host -e PGPASSWORD=kgalli_pw -v $PWD:/opt -w /opt postgres pg_dump -h 127.0.0.1 -p 5436 -U kgalli_us --verbose --no-security-labels --no-owner --if-exists --clean --no-tablespaces --no-privileges --format=custom --file kgalli-development.dump -d kgalli_db'
+      const expectedOutput = 'docker run --rm -it --net=host -e PGPASSWORD=kgalli_pw -v $PWD:/opt -w /opt postgres pg_dump -h 127.0.0.1 -p 5436 -U kgalli_us --verbose --no-security-labels --no-owner --if-exists --clean --no-tablespaces --no-privileges --disable-dollar-quoting --format=custom --file kgalli-development.dump -d kgalli_db'
 
       expect(ctx.stdout).to.contain(expectedOutput)
     })


### PR DESCRIPTION
Several times I faced issues when dumping the schema and then trying to import it. Most of the errors were related to the issue tackled with this PR.

In theory that should not be an issue in the first place but as it obviously is and it seems no harm to disable dollar quoting I'm going to make it the default.