### PR TITLE
Add [--command] and [--file] support for db console

### DIFF
--- a/src/commands/db/console.ts
+++ b/src/commands/db/console.ts
@@ -10,6 +10,12 @@ export default class Console extends DbToolsWrapper {
 
   static flags = {
     environment: environmentFlag,
+    command: flags.string({
+      char: 'c',
+      description: 'run only single command (SQL or internal) and exit',
+      multiple: false,
+      required: false
+    }),
     'dry-run': dryRunFlag,
     help: flags.help({char: 'h'})
   }
@@ -23,11 +29,13 @@ export default class Console extends DbToolsWrapper {
     const dataSource = args.datasource
     const environment = flags.environment
     const dryRun = flags['dry-run']
+    const command = flags.command
+    const options = flags.command ? {command} : {}
 
     try {
       await this
         .dbTools(dryRun)
-        .console({}, dataSource, environment)
+        .console(options, dataSource, environment)
     } catch (e) {
       this.error(e.message, e)
     }

--- a/src/commands/db/console.ts
+++ b/src/commands/db/console.ts
@@ -14,7 +14,15 @@ export default class Console extends DbToolsWrapper {
       char: 'c',
       description: 'run only single command (SQL or internal) and exit',
       multiple: false,
-      required: false
+      required: false,
+      exclusive: ['file']
+    }),
+    file: flags.string({
+      char: 'f',
+      description: 'execute commands from file, then exit',
+      multiple: false,
+      required: false,
+      exclusive: ['command']
     }),
     'dry-run': dryRunFlag,
     help: flags.help({char: 'h'})
@@ -30,7 +38,11 @@ export default class Console extends DbToolsWrapper {
     const environment = flags.environment
     const dryRun = flags['dry-run']
     const command = flags.command
-    const options = flags.command ? {command} : {}
+    const file = flags.file
+    const options = {
+      command,
+      file
+    }
 
     try {
       await this

--- a/src/wrapper/db-tools/postgre-sql.ts
+++ b/src/wrapper/db-tools/postgre-sql.ts
@@ -9,6 +9,14 @@ const defaultDockerOptions: DockerOptions = {
   volume: '/opt'
 }
 
+function stripEnclosingDoubleQuotes(value: string): string {
+  if (value.startsWith('"') && value.endsWith('"')) {
+    return value.substr(1, value.length)
+  }
+
+  return value
+}
+
 export default class PostgreSql {
   static psql(connectionParams: ConnectionParams, options: PsqlOptions) {
     const dockerOptions = {...defaultDockerOptions, ...options.docker}
@@ -24,7 +32,7 @@ export default class PostgreSql {
     }
 
     if (options.command) {
-      cmd.push(`-c ${options.command}`)
+      cmd.push(`-c "${stripEnclosingDoubleQuotes(options.command)}"`)
     }
 
     if (dockerOptions.enabled) {
@@ -111,7 +119,7 @@ export default class PostgreSql {
 
   dbCreate() {
     const connectionParams = {...this.connectionParams}
-    const createStatement = `"CREATE DATABASE ${connectionParams.database} WITH OWNER ${connectionParams.user} ENCODING 'UTF8' LC_COLLATE = 'en_US.utf8' LC_CTYPE = 'en_US.utf8';"`
+    const createStatement = `CREATE DATABASE ${connectionParams.database} WITH OWNER ${connectionParams.user} ENCODING 'UTF8' LC_COLLATE = 'en_US.utf8' LC_CTYPE = 'en_US.utf8';`
     const psqlOptions = {command: createStatement, docker: this.dockerOptions}
 
     connectionParams.database = 'template1'
@@ -120,7 +128,7 @@ export default class PostgreSql {
 
   dbDrop() {
     const connectionParams = {...this.connectionParams}
-    const dropStatement = `"DROP DATABASE IF EXISTS ${connectionParams.database};"`
+    const dropStatement = `DROP DATABASE IF EXISTS ${connectionParams.database};`
     const psqlOptions = {command: dropStatement, docker: this.dockerOptions}
 
     connectionParams.database = 'template1'

--- a/src/wrapper/db-tools/postgre-sql.ts
+++ b/src/wrapper/db-tools/postgre-sql.ts
@@ -35,6 +35,10 @@ export default class PostgreSql {
       cmd.push(`-c "${stripEnclosingDoubleQuotes(options.command)}"`)
     }
 
+    if (options.file) {
+      cmd.push(`-f "${stripEnclosingDoubleQuotes(options.file)}"`)
+    }
+
     if (dockerOptions.enabled) {
       return PostgreSql.asDockerCmd(cmd.join(' '), connectionParams.password, dockerOptions.volume)
     }

--- a/src/wrapper/db-tools/psql-options.ts
+++ b/src/wrapper/db-tools/psql-options.ts
@@ -2,5 +2,6 @@ import DockerOptions from './docker-options'
 
 export default interface PsqlOptions {
   docker?: DockerOptions
-  command: string
+  command?: string
+  file?: string
 }

--- a/test/commands/db/console.test.ts
+++ b/test/commands/db/console.test.ts
@@ -24,4 +24,21 @@ describe('db:console', () => {
 
       expect(ctx.stdout).to.contain(expectedOutput)
     })
+
+  test
+    .env(env)
+    .stdout()
+    .command(['db:console', 'api', '-f', '"db/inserts.sql"', '--dry-run'])
+    .it('invokes docker cmd to run commands given by file', ctx => {
+      const expectedOutput = `${expectedDockerCmdPrefix} psql -h 127.0.0.1 -p 5436 -U kgalli_us -d kgalli_db -f "db/inserts.sql"`
+
+      expect(ctx.stdout).to.contain(expectedOutput)
+    })
+
+  test
+    .env(env)
+    .stdout()
+    .command(['db:console', 'api', '-c', 'SELECT * FROM users LIMIT 1;', '-f', 'db/inserts.sql', '--dry-run'])
+    .catch(err => expect(err.message).to.eql('--file= cannot also be provided when using --command='))
+    .it('does not allow to use --command option together with --file option')
 })

--- a/test/commands/db/console.test.ts
+++ b/test/commands/db/console.test.ts
@@ -3,12 +3,24 @@ import {expect, test} from '@oclif/test'
 import {env} from '../../helper/test-helper'
 
 describe('db:console', () => {
+  const expectedDockerCmdPrefix = 'docker run --rm -it --net=host -e PGPASSWORD=kgalli_pw -v $PWD:/opt -w /opt postgres'
+
   test
     .env(env)
     .stdout()
     .command(['db:console', 'api', '--dry-run'])
     .it('invokes docker cmd to open a console', ctx => {
-      const expectedOutput = 'docker run --rm -it --net=host -e PGPASSWORD=kgalli_pw -v $PWD:/opt -w /opt postgres psql -h 127.0.0.1 -p 5436 -U kgalli_us -d kgalli_db'
+      const expectedOutput = `${expectedDockerCmdPrefix} psql -h 127.0.0.1 -p 5436 -U kgalli_us -d kgalli_db`
+
+      expect(ctx.stdout).to.contain(expectedOutput)
+    })
+
+  test
+    .env(env)
+    .stdout()
+    .command(['db:console', 'api', '-c', '"SELECT * FROM users LIMIT 1;"', '--dry-run'])
+    .it('invokes docker cmd to run given command', ctx => {
+      const expectedOutput = `${expectedDockerCmdPrefix} psql -h 127.0.0.1 -p 5436 -U kgalli_us -d kgalli_db -c "SELECT * FROM users LIMIT 1;"`
 
       expect(ctx.stdout).to.contain(expectedOutput)
     })


### PR DESCRIPTION
This PR adds support for executing a SQL command directly via `db:console -c <commend>`. Once the command finishes the console also terminates (default `psql` behavior).