### PR TITLE
feat: add service:list command

### DIFF
--- a/src/commands/service/list.ts
+++ b/src/commands/service/list.ts
@@ -1,0 +1,40 @@
+import {flags as flagsHelper} from '@oclif/command'
+import {cli} from 'cli-ux'
+
+import BaseCommand from '../../wrapper/service'
+
+export default class List extends BaseCommand {
+  static description = 'List service(s) metadata.'
+
+  static flags = {
+    help: flagsHelper.help({char: 'h'}),
+    ...cli.table.flags(),
+  }
+
+  async run(): Promise<void> {
+    const {flags} = this.parse(List)
+    const servicesMetadata = this.servicesMetadata()
+
+    cli.table(servicesMetadata, {
+      name: {
+        minWidth: 7,
+      },
+      description: {
+        get: row => row.description || '',
+      },
+      directory: {
+        get: row => row.directory || '',
+        extended: true,
+      },
+      repositoryUrl: {
+        get: row => row.repositoryUrl || '',
+        extended: true,
+      },
+      source: {
+      },
+    }, {
+      printLine: this.log,
+      ...flags,
+    })
+  }
+}

--- a/src/types/service-metadata-config.ts
+++ b/src/types/service-metadata-config.ts
@@ -8,6 +8,7 @@ export interface ServiceMetadataConfig {
 export interface ServiceMetadata {
   name: string;
   repositoryUrl: string;
+  description: string;
   directory: string;
   source: SourceOrigin;
 }

--- a/src/wrapper/service/index.ts
+++ b/src/wrapper/service/index.ts
@@ -16,7 +16,7 @@ import ServiceMetaConfigRepo from './config/service-meta-config-repo'
 import {ServiceImageOriginTypes} from '../../types/service-image-origin-types-config'
 import FileNotFoundError from '../../utils/file-not-found-error'
 import {ServiceOverrides} from '../../types/service-overrides-config'
-import {ServiceMetadataConfig} from '../../types/service-metadata-config'
+import {ServiceMetadata, ServiceMetadataConfig} from '../../types/service-metadata-config'
 
 export default abstract class extends BaseCommand {
   service(dryRun: boolean, environment: string): ServiceWrapper {
@@ -62,6 +62,12 @@ export default abstract class extends BaseCommand {
       dockerComposeConfigConstructor,
       shellCallback({dryRun, logger: this.log}),
     )
+  }
+
+  servicesMetadata(): ServiceMetadata[] {
+    const projectConfig = defaultProject
+
+    return this.loadServiceMetaConfig(projectConfig.configDir).services
   }
 
   imageOriginConfig(): ServiceImageOriginTypeConfigRepo {

--- a/test/commands/service/list.test.ts
+++ b/test/commands/service/list.test.ts
@@ -1,0 +1,24 @@
+import {expect, test} from '@oclif/test'
+
+import {
+  env,
+  removeProjectsConfigDefault,
+  writeProjectsConfigDefault,
+} from '../../helper/test-helper'
+
+describe('list', () => {
+  before(() => writeProjectsConfigDefault())
+  after(() => removeProjectsConfigDefault())
+
+  test
+  .env(env)
+  .stdout()
+  .command(['service:list'])
+  .it('runs status api', ctx => {
+    expect(ctx.stdout).to.contain(
+      'Name   Description         Source   \n' +
+      'api    API service         internal \n' +
+      'db     PostgreSQL database external ',
+    )
+  })
+})


### PR DESCRIPTION
Resolves #74.

`cliw service` now supports listing all services

```
Manage service(s) lifecycle using a container runtime.

USAGE
  $ cliw service:COMMAND

COMMANDS
  service:checkout  Checkout service(s) from version control.
  service:config    List, set or validate service(s) configuration.
  service:exec      Execute a command in a running service container.
  service:image     Manage service(s) container image.
  service:list      List service(s) metadata.
  service:logs      Show service(s) logs.
  service:run       Run a one-off command on a service.
  service:start     Start service(s) in daemon mode.
  service:status    Show service(s) run status.
  service:stop      Stop running service(s).
```

`cliw service:list --help`:

```
List service(s) metadata.

USAGE
  $ cliw service:list

OPTIONS
  -h, --help              show CLI help
  -x, --extended          show extra columns
  --columns=columns       only show provided columns (comma-separated)
  --csv                   output is csv format [alias: --output=csv]
  --filter=filter         filter property by partial string matching, ex: name=foo
  --no-header             hide table header from output
  --no-truncate           do not truncate output to fit screen
  --output=csv|json|yaml  output in a more machine friendly format
  --sort=sort             property to sort by (prepend '-' for descending)
```